### PR TITLE
conf CAS OK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target/
 .metadata
 ACEM-web-jsf-servlet/src/main/resources/properties/config.properties
 .checkstyle
+.idea
+*.iml

--- a/ACEM-web-jsf-servlet/src/main/resources/properties/applicationContext.xml
+++ b/ACEM-web-jsf-servlet/src/main/resources/properties/applicationContext.xml
@@ -22,8 +22,8 @@
 		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="locations">
 			<list>
-				<value>classpath:/properties/config.properties</value>
 				<value>classpath:/properties/defaults.properties</value>
+                <value>classpath:/properties/config.properties</value>
 			</list>
 		</property>
 	</bean>

--- a/ACEM-web-jsf-servlet/src/main/webapp/WEB-INF/web.xml
+++ b/ACEM-web-jsf-servlet/src/main/webapp/WEB-INF/web.xml
@@ -77,38 +77,43 @@
 	<listener>
 		<listener-class>org.springframework.web.context.request.RequestContextListener</listener-class>
 	</listener>
+
 	<filter>
 		<filter-name>CAS Authentication Filter</filter-name>
 		<filter-class>org.jasig.cas.client.authentication.AuthenticationFilter</filter-class>
 		<init-param>
 			<param-name>casServerLoginUrl</param-name>
-			<param-value>${cas.url}/login</param-value>
+			<param-value>https://sso-cas.univ-rennes1.fr/login</param-value>
 		</init-param>
 		<init-param>
 			<param-name>serverName</param-name>
 			<param-value>http://localhost:8080</param-value>
 		</init-param>
 	</filter>
+
 	<filter-mapping>
 		<filter-name>CAS Authentication Filter</filter-name>
 		<url-pattern>/stylesheets/cas.xhtml</url-pattern>
 	</filter-mapping>
+
 	<filter>
 		<filter-name>CAS Validation Filter</filter-name>
 		<filter-class>org.jasig.cas.client.validation.Cas10TicketValidationFilter</filter-class>
 		<init-param>
 			<param-name>casServerUrlPrefix</param-name>
-			<param-value>${cas.url}</param-value>
+			<param-value>https://sso-cas.univ-rennes1.fr</param-value>
 		</init-param>
 		<init-param>
 			<param-name>serverName</param-name>
 			<param-value>http://localhost:8080</param-value>
 		</init-param>
 	</filter>
+
 	<filter-mapping>
 		<filter-name>CAS Validation Filter</filter-name>
-		<url-pattern>/stylesheets/cas.xhtml</url-pattern>
+		<url-pattern>/*</url-pattern>
 	</filter-mapping>
+
 	<welcome-file-list>
 		<welcome-file>pages/accueil.xhtml</welcome-file>
 	</welcome-file-list>


### PR DESCRIPTION
En mettant config.preperties en 2eme dansapplicationContext.xml  je tiens compte du paramètre auth.bean=servletAuthenticationService de mon config.properties

Par contre pour que CAS renvoie une valeur (et non null) il faut : 
1) configurer l'application (Cf web.xml)
2) appeler l'application via http://localhost:8080/stylesheets/cas.xhtml (car le filtre est, pour le moment, configuré pour seulement fonctionner avec cette URL)

NB : On est obligé de mettre des valeurs "en dur" dans le web.xml. En effet ce dernier ne peut pas lire des paramètres contenus dans le config.preperties. Ce n'est pas un fichier Spring. 
Une solution consiste à utiliser DelegatingFilterProxy (pas mis en œuvre ici pour ne pas y passer trop de temps). Cf. un exemple dans esup-opi : 
https://github.com/EsupPortail/esup-opi/blob/develop/esup-opi-web-jsf-servlet/src/main/webapp/WEB-INF/web.xml
https://github.com/EsupPortail/esup-opi/blob/e949c799615c2923434a5c308cdbd5bfbf32d496/esup-opi-domain-services/src/main/resources/META-INF/auth/auth.xml
